### PR TITLE
Wire up resumable search state save/restore

### DIFF
--- a/src/BalatroSeedOracle/ViewModels/SearchModalViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/SearchModalViewModel.cs
@@ -538,11 +538,27 @@ namespace BalatroSeedOracle.ViewModels
             // Update button text when Continue checkbox changes
             OnPropertyChanged(nameof(CookButtonText));
 
-            // If user just enabled Continue while search is NOT running, reset progress.
-            // (Saved-progress restoration was removed when Motely took over DB ownership.)
             if (value && !IsSearching)
             {
-                ProgressPercent = 0.0;
+                var state = _userProfileService.GetSearchState();
+                if (state is not null
+                    && !string.IsNullOrEmpty(CurrentFilterPath)
+                    && string.Equals(state.ConfigPath, CurrentFilterPath, StringComparison.OrdinalIgnoreCase)
+                    && state.TotalBatches > 0)
+                {
+                    ProgressPercent = Math.Clamp(
+                        (double)state.LastCompletedBatch / state.TotalBatches * 100.0,
+                        0.0,
+                        100.0
+                    );
+                    AddConsoleMessage(
+                        $"Saved progress found — batch {state.LastCompletedBatch:N0} of {state.TotalBatches:N0} ({ProgressPercent:F1}%)"
+                    );
+                }
+                else
+                {
+                    ProgressPercent = 0.0;
+                }
             }
         }
 
@@ -699,6 +715,14 @@ namespace BalatroSeedOracle.ViewModels
                     $"Search started with ID: {_currentSearchId}"
                 );
 
+                // Persist initial resume state so the desktop icon comes back even if the
+                // user closes the app before the first periodic save (every 10 batches).
+                if (SelectedSearchMode == SearchMode.AllSeeds
+                    && !string.IsNullOrEmpty(CurrentFilterPath))
+                {
+                    _ = SaveSearchStateBackgroundAsync(0);
+                }
+
                 // Configure search transition (if enabled by user)
                 ConfigureSearchTransition();
             }
@@ -731,7 +755,16 @@ namespace BalatroSeedOracle.ViewModels
                         AddConsoleMessage("Pausing search and saving progress...");
                         BsoLogger.Log("SearchModalViewModel", "Pausing search (saving state)");
 
-                        // The SearchInstance already saves state periodically in OnProgressUpdated
+                        // Capture the latest known batch before stopping so the saved state
+                        // reflects exactly where the user paused, not whatever the last
+                        // every-10-batches tick happened to write.
+                        var pausedSeeds = LatestProgress?.SeedsSearched ?? 0UL;
+                        long pausedBatchSize = (long)Math.Pow(35, BatchSize + 1);
+                        int pausedBatch = pausedBatchSize > 0
+                            ? (int)(pausedSeeds / (ulong)pausedBatchSize)
+                            : 0;
+                        _ = SaveSearchStateBackgroundAsync(pausedBatch);
+
                         // We just need to stop gracefully without clearing the database
                         _searchContext.StopSearch();
                     }
@@ -1217,6 +1250,10 @@ namespace BalatroSeedOracle.ViewModels
             Avalonia.Threading.Dispatcher.UIThread.Post(async () =>
             {
                 IsSearching = false;
+
+                // A finished search has nothing to resume — drop the saved state so
+                // the desktop icon doesn't reappear on next launch.
+                _userProfileService.ClearSearchState();
 
                 // CRITICAL FIX: Load any remaining results from DuckDB into ObservableCollection
                 // (Real-time results are already added via OnResultFound, but load any missed ones)
@@ -2028,7 +2065,37 @@ namespace BalatroSeedOracle.ViewModels
 
         private Task SaveSearchStateBackgroundAsync(int currentBatch)
         {
-            // Search state persistence has been removed - Motely now owns all database operations
+            try
+            {
+                if (string.IsNullOrEmpty(CurrentFilterPath))
+                    return Task.CompletedTask;
+
+                var totalBatches = BatchSize >= 0 && BatchSize <= 7
+                    ? (ulong)Math.Pow(35, 7 - BatchSize)
+                    : 0UL;
+
+                var state = new Models.SearchResumeState
+                {
+                    ConfigPath = CurrentFilterPath,
+                    LastCompletedBatch = (ulong)Math.Max(0, currentBatch),
+                    EndBatch = ulong.MaxValue,
+                    BatchSize = BatchSize,
+                    ThreadCount = ThreadCount,
+                    MinScore = MinScore,
+                    Deck = DeckSelection,
+                    Stake = StakeSelection,
+                    LastActiveTime = DateTime.UtcNow,
+                    TotalBatches = totalBatches,
+                };
+                _userProfileService.SaveSearchState(state);
+            }
+            catch (Exception ex)
+            {
+                BsoLogger.LogError(
+                    "SearchModalViewModel",
+                    $"Error saving search state: {ex.Message}"
+                );
+            }
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Summary

Happy birthday pifreak + BSO! 🎂 This finishes the "save feature" that was already half-built in the codebase. Every supporting piece for resumable search state across app restarts already existed — `UserProfile.LastSearchState`, the full `SearchResumeState` model, `UserProfileService.SaveSearchState/GetSearchState/ClearSearchState`, the "Continue from last position" checkbox, and `BalatroMainMenuViewModel.CheckAndRestoreSearchIcon` on main-menu load — but `SaveSearchStateBackgroundAsync` was a no-op stub left behind when Motely took over per-search DB ownership. So `LastSearchState` in `userprofile.json` stayed `null`, the desktop icon never came back, and toggling Continue silently set progress to 0.

All changes live in **one file**: `src/BalatroSeedOracle/ViewModels/SearchModalViewModel.cs`.

- **Replace the no-op stub** with a real implementation that snapshots `CurrentFilterPath`, `BatchSize`, `ThreadCount`, `MinScore`, `DeckSelection`, `StakeSelection`, `LastCompletedBatch`, `TotalBatches = 35^(7-BatchSize)`, and `LastActiveTime` into a `SearchResumeState` and persists via `UserProfileService.SaveSearchState`.
- **Initial save on search start** — guarantees the desktop icon reappears even if the user closes the app before the first every-10-batches tick.
- **Save on Pause** (StopSearch with Continue enabled) using `LatestProgress?.SeedsSearched` to capture the actual pause point, not whatever the last periodic tick happened to write. `CurrentBatch` was dead code (only ever set to 0).
- **Clear saved state on natural completion** — a finished search has nothing to resume.
- **Surface saved progress** when the user ticks Continue: if a saved state's `ConfigPath` matches the currently loaded filter and `TotalBatches > 0`, set `ProgressPercent` and print `Saved progress found — batch X of Y (Z%)` to the console so the resume is visible rather than a silent checkbox.

## Scope notes

- AllSeeds only. SingleSeed, WordList, and DbList modes intentionally don't touch saved state.
- No expiry — matches the existing comment at `BalatroMainMenuViewModel.cs:968` ("User will close searches they don't want — no need for auto-cleanup").
- No model, service, XAML, or DI changes. Every type and member referenced already exists.
- No Motely-side changes; the per-search DB resume Motely owns is independent and unchanged.

## Test plan

- [ ] Load any filter from `JamlFilters/`, pick deck/stake, click **Start Search**. Wait ~2s for the debounced profile save, confirm `User/userprofile.json` now has a populated `LastSearchState` block.
- [ ] Let the search run >10 batches; confirm `LastCompletedBatch` ticks up in the JSON.
- [ ] Close the app cleanly, reopen. Search desktop icon should reappear via `CheckAndRestoreSearchIcon`.
- [ ] Click icon → modal opens → tick **Continue from last position**. Console should print `Saved progress found — batch X of Y (Z%)` and the progress bar should reflect the saved fraction.
- [ ] Click **Resume Search** → Motely picks up from its own DB (existing behavior, untouched).
- [ ] Let the search run to natural completion. `LastSearchState` should return to `null`.
- [ ] Stop a search with Continue OFF → saved state is untouched (intentional, lets users pause-then-untoggle without losing state).

## Build verification

`dotnet` is not available in this remote execution environment, so I couldn't run the build locally. All referenced types and members were verified by direct file inspection; the changes are conservative C# that introduces no new dependencies. Please run `dotnet build src/BalatroSeedOracle/BalatroSeedOracle.csproj -c Release` locally / via CI before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jzWsu4NEHimCer37JBkNC)_