### PR TITLE
Kill ServiceHelper anti-pattern (Phase A: service layer)

### DIFF
--- a/src/BalatroSeedOracle/App.axaml.cs
+++ b/src/BalatroSeedOracle/App.axaml.cs
@@ -45,6 +45,10 @@ public partial class App : Application
             ConfigureServices(services);
             _serviceProvider = services.BuildServiceProvider();
 
+            // Eagerly construct singletons that publish a static .Instance for
+            // XAML-constructed callers (converters/behaviors) that can't use DI.
+            _ = _serviceProvider.GetService<Services.FavoritesService>();
+
             // Get platform services for platform-specific initialization
             var platformServices = _serviceProvider.GetService<Services.IPlatformServices>();
             if (platformServices is not null)

--- a/src/BalatroSeedOracle/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BalatroSeedOracle/Extensions/ServiceCollectionExtensions.cs
@@ -23,13 +23,15 @@ namespace BalatroSeedOracle.Extensions
             // Note: IAppDataStore and IPlatformServices are registered by platform-specific projects (Desktop/Browser)
             // IApiHostService is also registered by platform-specific projects
 
-            services.AddSingleton<IFilterService>(sp => new FilterService(
-                sp.GetRequiredService<IConfigurationService>(),
+            services.AddSingleton<IFilterCacheService>(sp => new FilterCacheService(
                 sp.GetRequiredService<IAppDataStore>(),
                 sp.GetService<IPlatformServices>()
             ));
-            services.AddSingleton<IFilterCacheService>(sp => new FilterCacheService(
+            services.AddSingleton<IFilterService>(sp => new FilterService(
+                sp.GetRequiredService<IConfigurationService>(),
                 sp.GetRequiredService<IAppDataStore>(),
+                sp.GetRequiredService<IFilterCacheService>(),
+                sp.GetRequiredService<UserProfileService>(),
                 sp.GetService<IPlatformServices>()
             ));
             services.AddSingleton<SpriteService>();
@@ -50,8 +52,12 @@ namespace BalatroSeedOracle.Extensions
                 sp.GetService<Views.MainWindow>(),
                 sp.GetService<Views.BalatroMainMenu>()
             ));
-            services.AddSingleton<FavoritesService>(_ => FavoritesService.Instance);
-            services.AddSingleton<DaylatroHighScoreService>();
+            services.AddSingleton<FavoritesService>(sp => new FavoritesService(
+                sp.GetService<IPlatformServices>()
+            ));
+            services.AddSingleton<DaylatroHighScoreService>(sp => new DaylatroHighScoreService(
+                sp.GetService<IPlatformServices>()
+            ));
             services.AddSingleton<FilterSerializationService>();
             services.AddSingleton<WidgetPositionService>();
             services.AddSingleton<WidgetWindowManager>();
@@ -69,6 +75,7 @@ namespace BalatroSeedOracle.Extensions
                 sp.GetRequiredService<FiltersModalViewModel>(),
                 sp.GetRequiredService<CreditsModalViewModel>(),
                 sp.GetRequiredService<Func<AnalyzeModalViewModel>>(),
+                sp.GetRequiredService<WidgetWindowManager>(),
                 sp.GetService<IAudioManager>(),
                 sp.GetService<EventFXService>(),
                 sp.GetService<WidgetPositionService>(),

--- a/src/BalatroSeedOracle/Services/DaylatroHighScoreService.cs
+++ b/src/BalatroSeedOracle/Services/DaylatroHighScoreService.cs
@@ -17,17 +17,13 @@ namespace BalatroSeedOracle.Services
     /// </summary>
     public class DaylatroHighScoreService
     {
-        private static readonly Lazy<DaylatroHighScoreService> _lazy = new(() =>
-            new DaylatroHighScoreService()
-        );
-        public static DaylatroHighScoreService Instance => _lazy.Value;
-
         private const string DAYLATRO_URL = "https://daylatro.fly.dev";
         private static readonly HttpClient _httpClient = new HttpClient
         {
             Timeout = TimeSpan.FromSeconds(10),
         };
 
+        private readonly IPlatformServices? _platformServices;
         private readonly string _dataPath;
         private readonly string _submissionsPath;
         private readonly Dictionary<string, DaylatroDailyScores> _cache = new();
@@ -43,8 +39,9 @@ namespace BalatroSeedOracle.Services
         // Track submissions per day (UTC)
         private readonly Dictionary<string, DateTime> _lastSubmissionDates = new();
 
-        private DaylatroHighScoreService()
+        public DaylatroHighScoreService(IPlatformServices? platformServices = null)
         {
+            _platformServices = platformServices;
             var baseDir = AppContext.BaseDirectory;
             _dataPath = Path.Combine(baseDir, "daylatro_scores.json");
             _submissionsPath = Path.Combine(baseDir, "daylatro_submissions.json");
@@ -56,8 +53,7 @@ namespace BalatroSeedOracle.Services
             if (_loaded)
                 return;
 
-            var platformServices = ServiceHelper.GetService<IPlatformServices>();
-            if (platformServices == null || !platformServices.SupportsFileSystem)
+            if (_platformServices == null || !_platformServices.SupportsFileSystem)
             {
                 // Browser: Skip file loading
                 _loaded = true;
@@ -116,8 +112,7 @@ namespace BalatroSeedOracle.Services
 
         private void LoadSubmissionDates()
         {
-            var platformServices = ServiceHelper.GetService<IPlatformServices>();
-            if (platformServices == null || !platformServices.SupportsFileSystem)
+            if (_platformServices == null || !_platformServices.SupportsFileSystem)
             {
                 // Browser: Skip file loading
                 return;

--- a/src/BalatroSeedOracle/Services/FavoritesService.cs
+++ b/src/BalatroSeedOracle/Services/FavoritesService.cs
@@ -12,23 +12,31 @@ namespace BalatroSeedOracle.Services
     public class FavoritesService
     {
         private static FavoritesService? _instance;
-        public static FavoritesService Instance => _instance ??= new FavoritesService();
+        public static FavoritesService Instance =>
+            _instance ?? throw new InvalidOperationException(
+                "FavoritesService not initialized. Call Initialize() at app startup."
+            );
 
         private readonly string _favoritesPath;
+        private readonly IPlatformServices? _platformServices;
         private FavoritesData _data = new FavoritesData();
 
-        private FavoritesService()
+        public FavoritesService(IPlatformServices? platformServices)
         {
+            _platformServices = platformServices;
             _favoritesPath = Path.Combine(AppPaths.DataRootDir, "favorites.json");
 
             LoadFavorites();
             InitializeDefaultSets();
+
+            // Publish for XAML-constructed callers (converters/behaviors/code-behind
+            // that have no DI access). DI always wins; this is a fallback accessor.
+            _instance = this;
         }
 
         private void LoadFavorites()
         {
-            var platformServices = ServiceHelper.GetService<IPlatformServices>();
-            if (platformServices is null || !platformServices.SupportsFileSystem)
+            if (_platformServices is null || !_platformServices.SupportsFileSystem)
             {
                 // Browser: Skip file loading, use empty data
                 _data = new FavoritesData();

--- a/src/BalatroSeedOracle/Services/FilterService.cs
+++ b/src/BalatroSeedOracle/Services/FilterService.cs
@@ -23,16 +23,22 @@ namespace BalatroSeedOracle.Services
     {
         private readonly IConfigurationService _configurationService;
         private readonly IAppDataStore _store;
+        private readonly IFilterCacheService _filterCache;
+        private readonly UserProfileService _userProfileService;
         private readonly IPlatformServices? _platformServices;
 
         public FilterService(
             IConfigurationService configurationService,
             IAppDataStore store,
+            IFilterCacheService filterCache,
+            UserProfileService userProfileService,
             IPlatformServices? platformServices = null
         )
         {
             _configurationService = configurationService;
             _store = store;
+            _filterCache = filterCache;
+            _userProfileService = userProfileService;
             _platformServices = platformServices;
         }
 
@@ -107,10 +113,8 @@ namespace BalatroSeedOracle.Services
                         File.Delete(filePath);
                     }
 
-                    // Remove from cache (use ServiceHelper to avoid circular dependency)
                     var filterId = Path.GetFileNameWithoutExtension(filePath);
-                    var filterCache = Helpers.ServiceHelper.GetService<IFilterCacheService>();
-                    filterCache?.RemoveFilter(filterId);
+                    _filterCache.RemoveFilter(filterId);
 
                     return true;
                 }
@@ -265,9 +269,7 @@ namespace BalatroSeedOracle.Services
 
                 config.Name = newName;
                 config.DateCreated = DateTime.UtcNow.ToString("o");
-                config.Author =
-                    Helpers.ServiceHelper.GetService<UserProfileService>()?.GetAuthorName()
-                    ?? "Unknown";
+                config.Author = _userProfileService.GetAuthorName() ?? "Unknown";
 
                 var newId = $"{newName.Replace(" ", "").ToLower()}_{Guid.NewGuid():N}";
                 var newPath = Path.Combine(filtersDir, $"{newId}.json");

--- a/src/BalatroSeedOracle/Services/SoundEffectsService.cs
+++ b/src/BalatroSeedOracle/Services/SoundEffectsService.cs
@@ -9,7 +9,13 @@ namespace BalatroSeedOracle.Services
     /// </summary>
     public class SoundEffectsService
     {
+        private readonly IAudioManager _audioManager;
         private float _volume = 1.0f;
+
+        public SoundEffectsService(IAudioManager audioManager)
+        {
+            _audioManager = audioManager;
+        }
 
         public float Volume
         {
@@ -25,8 +31,7 @@ namespace BalatroSeedOracle.Services
             try
             {
                 var effectiveVolume = _volume * volumeMultiplier;
-                var audioManager = ServiceHelper.GetService<IAudioManager>();
-                audioManager?.PlaySfx(soundName, effectiveVolume);
+                _audioManager.PlaySfx(soundName, effectiveVolume);
             }
             catch (Exception ex)
             {

--- a/src/BalatroSeedOracle/Services/WidgetWindowManager.cs
+++ b/src/BalatroSeedOracle/Services/WidgetWindowManager.cs
@@ -17,12 +17,9 @@ namespace BalatroSeedOracle.Services
         private readonly List<BaseWidgetViewModel> _activeWidgets = new();
         private readonly WidgetPositionService _positionService;
 
-        public static WidgetWindowManager Instance { get; } = new();
-
-        private WidgetWindowManager()
+        public WidgetWindowManager(WidgetPositionService positionService)
         {
-            _positionService =
-                ServiceHelper.GetService<WidgetPositionService>() ?? new WidgetPositionService();
+            _positionService = positionService;
         }
 
         /// <summary>

--- a/src/BalatroSeedOracle/ViewModels/BalatroMainMenuViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/BalatroMainMenuViewModel.cs
@@ -25,6 +25,7 @@ namespace BalatroSeedOracle.ViewModels
         private readonly IAudioManager? _audioManager;
         private readonly EventFXService? _eventFXService;
         private readonly IPlatformServices? _platformServices;
+        private readonly WidgetWindowManager _widgetWindowManager;
         private Action<float, float, float, float>? _audioAnalysisHandler;
 
         // Effect source tracking
@@ -213,6 +214,7 @@ namespace BalatroSeedOracle.ViewModels
             FiltersModalViewModel filtersModalViewModel,
             CreditsModalViewModel creditsModalViewModel,
             Func<AnalyzeModalViewModel> analyzeModalFactory,
+            WidgetWindowManager widgetWindowManager,
             IAudioManager? audioManager = null,
             EventFXService? eventFXService = null,
             WidgetPositionService? widgetPositionService = null,
@@ -226,6 +228,7 @@ namespace BalatroSeedOracle.ViewModels
             SearchModalViewModel = searchModalViewModel;
             FiltersModalViewModel = filtersModalViewModel;
             CreditsModalViewModel = creditsModalViewModel;
+            _widgetWindowManager = widgetWindowManager;
             _audioManager = audioManager;
             _eventFXService = eventFXService;
             _platformServices = platformServices;
@@ -233,6 +236,9 @@ namespace BalatroSeedOracle.ViewModels
             // Load settings
             LoadSettings();
         }
+
+        /// <summary>Exposes the WidgetWindowManager to the View (needed for code-behind widget restore).</summary>
+        public WidgetWindowManager WidgetWindowManager => _widgetWindowManager;
 
         /// <summary>Creates an AnalyzeModalViewModel via DI factory (no ServiceHelper). Used by View to show analyze modal.</summary>
         public AnalyzeModalViewModel CreateAnalyzeModalViewModel() => _analyzeModalFactory();
@@ -546,7 +552,7 @@ namespace BalatroSeedOracle.ViewModels
             IsSearchWidgetsVisible = newState;
 
             // Show/hide search widgets via window manager
-            var widgetManager = WidgetWindowManager.Instance;
+            var widgetManager = _widgetWindowManager;
             if (newState)
             {
                 widgetManager.ShowAllWidgets();
@@ -564,7 +570,7 @@ namespace BalatroSeedOracle.ViewModels
             IsSearchWidgetsVisible = !IsSearchWidgetsVisible;
 
             // Show/hide all search widgets via window manager
-            var widgetManager = WidgetWindowManager.Instance;
+            var widgetManager = _widgetWindowManager;
             if (IsSearchWidgetsVisible)
             {
                 widgetManager.ShowAllWidgets();
@@ -617,7 +623,7 @@ namespace BalatroSeedOracle.ViewModels
                 IsSearchWidgetsVisible = false;
 
                 // Hide search widgets via window manager
-                var widgetManager = WidgetWindowManager.Instance;
+                var widgetManager = _widgetWindowManager;
                 widgetManager.HideAllWidgets();
             }
             else
@@ -625,7 +631,7 @@ namespace BalatroSeedOracle.ViewModels
                 IsSearchWidgetsVisible = true;
 
                 // Show search widgets via window manager
-                var widgetManager = WidgetWindowManager.Instance;
+                var widgetManager = _widgetWindowManager;
                 widgetManager.ShowAllWidgets();
             }
 

--- a/src/BalatroSeedOracle/Views/BalatroMainMenu.axaml.cs
+++ b/src/BalatroSeedOracle/Views/BalatroMainMenu.axaml.cs
@@ -2011,7 +2011,7 @@ namespace BalatroSeedOracle.Views
                     viewModel.IsMinimized = true;
 
                     // Use the new window manager instead of desktop canvas
-                    var widgetManager = WidgetWindowManager.Instance;
+                    var widgetManager = ViewModel.WidgetWindowManager;
                     widgetManager.CreateWidget(viewModel);
                 }
 
@@ -2042,7 +2042,7 @@ namespace BalatroSeedOracle.Views
             try
             {
                 // Find the widget in the window manager (works on all platforms)
-                var widgetManager = WidgetWindowManager.Instance;
+                var widgetManager = ViewModel.WidgetWindowManager;
                 var activeWidgets = widgetManager.GetActiveWidgets();
 
                 var widgetToRemove = activeWidgets.FirstOrDefault(w =>


### PR DESCRIPTION
## Summary

First commit of a phased refactor to eliminate the `ServiceHelper` static
service-locator anti-pattern (108 call sites across 38 files; see
`/root/.claude/plans/system-reminder-you-re-running-in-typed-porcupine.md`).

**Phase A — service layer (this commit):**
- `FilterService` now ctor-injects `IFilterCacheService` + `UserProfileService`. The "circular dependency" comment was wrong; there is no cycle.
- `SoundEffectsService` ctor-injects `IAudioManager`.
- `WidgetWindowManager` drops its static `.Instance` singleton entirely and is resolved through DI; `BalatroMainMenuViewModel` exposes it to the View so code-behind doesn't reach into globals.
- `FavoritesService` keeps its static `.Instance` for the unavoidable XAML-constructed callers (eagerly resolved at App startup), but construction itself now goes through DI with `IPlatformServices` injected.
- `DaylatroHighScoreService` ctor-injects `IPlatformServices`; old `.Instance` removed (had no callers).

No UI surface area touched yet — phases B–F follow in subsequent commits on this branch.

## Test plan

- [ ] `dotnet build BalatroSeedOracle.sln -c Release` clean
- [ ] Desktop app launches; main menu intro plays normally
- [ ] Create / save / delete a filter (exercises FilterService + UserProfile + FilterCache)
- [ ] Trigger a card hover sound (exercises SoundEffectsService → IAudioManager)
- [ ] Open + close a search widget (exercises WidgetWindowManager via VM)
- [ ] Daylatro widget loads scores (exercises DaylatroHighScoreService)
- [ ] Open Favorites in Visual Builder (exercises FavoritesService.Instance bootstrap)

---
_Generated by [Claude Code](https://claude.ai/code/session_013mqW4xZQPLkeHs4ykzGs4W)_