### PR TITLE
Kill ServiceHelper anti-pattern (Phase B: ViewModel layer)

### DIFF
--- a/src/BalatroSeedOracle/Components/FilterSelectorControl.axaml.cs
+++ b/src/BalatroSeedOracle/Components/FilterSelectorControl.axaml.cs
@@ -59,7 +59,8 @@ namespace BalatroSeedOracle.Components
 
         private void InitializeViewModel()
         {
-            _viewModel = new FilterListViewModel();
+            _viewModel = App.GetService<FilterListViewModel>()
+                ?? throw new InvalidOperationException("FilterListViewModel not registered");
             DataContext = _viewModel;
 
             // Wire up SizeChanged event for dynamic pagination

--- a/src/BalatroSeedOracle/Components/PaginatedFilterBrowser.axaml.cs
+++ b/src/BalatroSeedOracle/Components/PaginatedFilterBrowser.axaml.cs
@@ -92,7 +92,8 @@ namespace BalatroSeedOracle.Components
 
         public PaginatedFilterBrowser()
         {
-            ViewModel = new PaginatedFilterBrowserViewModel();
+            ViewModel = App.GetService<PaginatedFilterBrowserViewModel>()
+                ?? throw new InvalidOperationException("PaginatedFilterBrowserViewModel not registered");
             DataContext = ViewModel;
 
             InitializeComponent();

--- a/src/BalatroSeedOracle/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BalatroSeedOracle/Extensions/ServiceCollectionExtensions.cs
@@ -72,7 +72,8 @@ namespace BalatroSeedOracle.Extensions
                 sp.GetService<IAudioManager>(),
                 sp.GetService<EventFXService>(),
                 sp.GetService<WidgetPositionService>(),
-                sp.GetService<IPlatformServices>()
+                sp.GetService<IPlatformServices>(),
+                () => sp.GetRequiredService<FilterSelectionModalViewModel>()
             ));
 
             // Views
@@ -97,7 +98,11 @@ namespace BalatroSeedOracle.Extensions
                 sp.GetRequiredService<IConfigurationService>(),
                 sp.GetRequiredService<IFilterService>(),
                 sp.GetRequiredService<IPlatformServices>(),
-                sp.GetService<NotificationService>()
+                sp.GetService<NotificationService>(),
+                sp.GetService<UserProfileService>(),
+                sp.GetService<SearchManager>(),
+                sp.GetService<FilterSerializationService>(),
+                () => sp.GetRequiredService<ViewModels.FilterTabs.ValidateFilterTabViewModel>()
             ));
             services.AddSingleton<SearchModalViewModel>(sp => new SearchModalViewModel(
                 sp.GetRequiredService<SearchManager>(),
@@ -126,25 +131,62 @@ namespace BalatroSeedOracle.Extensions
             services.AddTransient<EventFXWidgetViewModel>();
             services.AddTransient<DeckAndStakeViewModel>();
             services.AddTransient<BaseWidgetViewModel>();
-            services.AddTransient<FilterListViewModel>();
-            services.AddTransient<PaginatedFilterBrowserViewModel>();
-            services.AddTransient<FilterSelectionModalViewModel>();
+            services.AddTransient<FilterListViewModel>(sp => new FilterListViewModel(
+                sp.GetRequiredService<IFilterCacheService>(),
+                sp.GetService<SpriteService>()
+            ));
+            services.AddTransient<PaginatedFilterBrowserViewModel>(sp => new PaginatedFilterBrowserViewModel(
+                sp.GetRequiredService<IFilterCacheService>(),
+                sp.GetService<UserProfileService>()
+            ));
+            services.AddTransient<FilterSelectionModalViewModel>(sp => new FilterSelectionModalViewModel(
+                sp.GetRequiredService<IFilterService>(),
+                sp.GetRequiredService<PaginatedFilterBrowserViewModel>()
+            ));
 
             // Filter Tab ViewModels
-            services.AddTransient<ViewModels.FilterTabs.VisualBuilderTabViewModel>();
+            services.AddTransient<ViewModels.FilterTabs.VisualBuilderTabViewModel>(sp =>
+                new ViewModels.FilterTabs.VisualBuilderTabViewModel(
+                    sp.GetService<FiltersModalViewModel>(),
+                    sp.GetService<FavoritesService>(),
+                    sp.GetService<IConfigurationService>(),
+                    sp.GetService<IFilterService>()
+                )
+            );
             services.AddTransient<ViewModels.FilterTabs.DeckStakeTabViewModel>();
-            services.AddTransient<ViewModels.FilterTabs.JsonEditorTabViewModel>();
-            services.AddTransient<ViewModels.FilterTabs.ValidateFilterTabViewModel>();
+            services.AddTransient<ViewModels.FilterTabs.JsonEditorTabViewModel>(sp =>
+                new ViewModels.FilterTabs.JsonEditorTabViewModel(
+                    sp.GetService<FiltersModalViewModel>(),
+                    sp.GetService<FilterSerializationService>()
+                )
+            );
+            services.AddTransient<ViewModels.FilterTabs.ValidateFilterTabViewModel>(sp =>
+                new ViewModels.FilterTabs.ValidateFilterTabViewModel(
+                    sp.GetRequiredService<FiltersModalViewModel>(),
+                    sp.GetRequiredService<IConfigurationService>(),
+                    sp.GetRequiredService<IFilterService>(),
+                    sp.GetRequiredService<IPlatformServices>(),
+                    sp.GetService<FilterSerializationService>(),
+                    sp.GetService<SearchManager>()
+                )
+            );
             services.AddTransient<ViewModels.FilterTabs.SaveFilterTabViewModel>(
                 sp => new ViewModels.FilterTabs.SaveFilterTabViewModel(
                     sp.GetRequiredService<FiltersModalViewModel>(),
                     sp.GetRequiredService<IConfigurationService>(),
                     sp.GetRequiredService<IFilterService>(),
                     sp.GetRequiredService<IPlatformServices>(),
-                    sp.GetService<NotificationService>()
+                    sp.GetService<NotificationService>(),
+                    sp.GetService<FilterSerializationService>(),
+                    sp.GetService<SearchManager>()
                 )
             );
-            services.AddTransient<ViewModels.FilterTabs.ConfigureFilterTabViewModel>();
+            services.AddTransient<ViewModels.FilterTabs.ConfigureFilterTabViewModel>(sp =>
+                new ViewModels.FilterTabs.ConfigureFilterTabViewModel(
+                    sp.GetService<FiltersModalViewModel>(),
+                    sp.GetService<IConfigurationService>()
+                )
+            );
 
             return services;
         }

--- a/src/BalatroSeedOracle/Helpers/ModalHelper.cs
+++ b/src/BalatroSeedOracle/Helpers/ModalHelper.cs
@@ -61,15 +61,13 @@ namespace BalatroSeedOracle.Helpers
             bool enableAnalyze = false
         )
         {
-            var vm = new FilterSelectionModalViewModel(
-                enableSearch,
-                enableEdit,
-                enableCopy,
-                enableDelete,
-                enableAnalyze
-            );
-            var configurationService = ServiceHelper.GetRequiredService<IConfigurationService>();
-            var filterService = ServiceHelper.GetRequiredService<IFilterService>();
+            var configurationService = App.GetService<IConfigurationService>()
+                ?? throw new InvalidOperationException("IConfigurationService not registered");
+            var filterService = App.GetService<IFilterService>()
+                ?? throw new InvalidOperationException("IFilterService not registered");
+            var vm = App.GetService<FilterSelectionModalViewModel>()
+                ?? throw new InvalidOperationException("FilterSelectionModalViewModel not registered");
+            vm.Configure(enableSearch, enableEdit, enableCopy, enableDelete, enableAnalyze);
             var modal = new FilterSelectionModal(vm, configurationService, filterService);
 
             var result = await modal.ShowDialog(menu.GetWindow());
@@ -208,7 +206,8 @@ namespace BalatroSeedOracle.Helpers
         /// <returns>The created modal</returns>
         public static StandardModal ShowToolsModal(this Views.BalatroMainMenu menu)
         {
-            var userProfile = ServiceHelper.GetRequiredService<UserProfileService>();
+            var userProfile = App.GetService<UserProfileService>()
+                ?? throw new InvalidOperationException("UserProfileService not registered");
             var ToolView = new ToolsModal(userProfile);
             return menu.ShowModal("MORE", ToolView);
         }
@@ -452,8 +451,7 @@ namespace BalatroSeedOracle.Helpers
             {
                 Name = "New Filter",
                 Description = "Created with Filter Designer",
-                Author =
-                    ServiceHelper.GetService<UserProfileService>()?.GetAuthorName() ?? "Unknown",
+                Author = App.GetService<UserProfileService>()?.GetAuthorName() ?? "Unknown",
                 DateCreated = DateTime.UtcNow.ToString("o"),
                 Must = new System.Collections.Generic.List<JamlClauseUnion>(),
                 Should = new System.Collections.Generic.List<JamlClauseUnion>(),
@@ -488,8 +486,7 @@ namespace BalatroSeedOracle.Helpers
                 {
                     config.Name = $"{config.Name} (Copy)";
                     config.Author =
-                        ServiceHelper.GetService<UserProfileService>()?.GetAuthorName()
-                        ?? "Unknown";
+                        App.GetService<UserProfileService>()?.GetAuthorName() ?? "Unknown";
                     config.DateCreated = DateTime.UtcNow.ToString("o");
 
                     var clonedPath = System.IO.Path.Combine(AppPaths.FiltersDir, $"{config.Name}.json");

--- a/src/BalatroSeedOracle/ViewModels/BalatroMainMenuViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/BalatroMainMenuViewModel.cs
@@ -22,6 +22,7 @@ namespace BalatroSeedOracle.ViewModels
     {
         private readonly UserProfileService _userProfileService;
         private readonly Func<AnalyzeModalViewModel> _analyzeModalFactory;
+        private readonly Func<FilterSelectionModalViewModel>? _filterSelectionFactory;
         private readonly IAudioManager? _audioManager;
         private readonly EventFXService? _eventFXService;
         private readonly IPlatformServices? _platformServices;
@@ -216,13 +217,15 @@ namespace BalatroSeedOracle.ViewModels
             IAudioManager? audioManager = null,
             EventFXService? eventFXService = null,
             WidgetPositionService? widgetPositionService = null,
-            IPlatformServices? platformServices = null
+            IPlatformServices? platformServices = null,
+            Func<FilterSelectionModalViewModel>? filterSelectionFactory = null
         )
         {
             // Store injected services
             _userProfileService = userProfileService;
             _analyzeModalFactory =
                 analyzeModalFactory ?? throw new ArgumentNullException(nameof(analyzeModalFactory));
+            _filterSelectionFactory = filterSelectionFactory;
             SearchModalViewModel = searchModalViewModel;
             FiltersModalViewModel = filtersModalViewModel;
             CreditsModalViewModel = creditsModalViewModel;
@@ -346,7 +349,13 @@ namespace BalatroSeedOracle.ViewModels
             _eventFXService?.TriggerEvent(EventFXType.SearchLaunchModal);
             try
             {
-                var filterSelectionVM = new FilterSelectionModalViewModel(
+                if (_filterSelectionFactory is null)
+                {
+                    DebugLogger.LogError("BalatroMainMenuViewModel", "FilterSelectionModalViewModel factory not registered");
+                    return;
+                }
+                var filterSelectionVM = _filterSelectionFactory();
+                filterSelectionVM.Configure(
                     enableSearch: true,
                     enableEdit: true,
                     enableCopy: false,
@@ -368,8 +377,8 @@ namespace BalatroSeedOracle.ViewModels
                         && !string.IsNullOrEmpty(result.FilterId)
                     )
                     {
-                        // Transition to SearchModal
-                        var searchVM = ServiceHelper.GetRequiredService<SearchModalViewModel>();
+                        // Transition to SearchModal using the injected VM
+                        var searchVM = SearchModalViewModel;
                         searchVM.MainMenu = null; // We'll handle navigation via ActiveModal
 
                         // Load filter and show

--- a/src/BalatroSeedOracle/ViewModels/BaseWidgetViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/BaseWidgetViewModel.cs
@@ -210,12 +210,11 @@ namespace BalatroSeedOracle.ViewModels
                 WidgetWindow = window;
 
                 // Set initial position using position service
-                var positionService = ServiceHelper.GetService<Services.WidgetPositionService>();
-                if (positionService is not null)
+                if (_widgetPositionService is not null)
                 {
-                    var (x, y) = positionService.FindNextAvailablePosition(this, IsMinimized);
+                    var (x, y) = _widgetPositionService.FindNextAvailablePosition(this, IsMinimized);
                     window.Position = new PixelPoint((int)x, (int)y);
-                    positionService.RegisterWidget(this);
+                    _widgetPositionService.RegisterWidget(this);
                 }
 
                 window.Show();
@@ -256,8 +255,7 @@ namespace BalatroSeedOracle.ViewModels
         private void CloseWidget()
         {
             // Unregister from position service
-            var positionService = ServiceHelper.GetService<Services.WidgetPositionService>();
-            positionService?.UnregisterWidget(this);
+            _widgetPositionService?.UnregisterWidget(this);
 
             // Close and cleanup window
             if (WidgetWindow is not null)

--- a/src/BalatroSeedOracle/ViewModels/FilterListViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterListViewModel.cs
@@ -23,6 +23,7 @@ namespace BalatroSeedOracle.ViewModels
         private const double ITEM_HEIGHT = 23.0; // default fallback: 22px button + 1px safety
 
         private readonly IFilterCacheService _filterCacheService;
+        private readonly SpriteService? _spriteService;
 
         [ObservableProperty]
         private int _filtersPerPage = DEFAULT_FILTERS_PER_PAGE;
@@ -102,9 +103,10 @@ namespace BalatroSeedOracle.ViewModels
 
         private List<FilterListItem> _allFilters = new();
 
-        public FilterListViewModel()
+        public FilterListViewModel(IFilterCacheService filterCacheService, SpriteService? spriteService = null)
         {
-            _filterCacheService = ServiceHelper.GetRequiredService<IFilterCacheService>();
+            _filterCacheService = filterCacheService;
+            _spriteService = spriteService;
             LoadFilters();
         }
 
@@ -328,12 +330,10 @@ namespace BalatroSeedOracle.ViewModels
                     SelectedFilterDescription = config.Description;
                 }
 
-                var spriteService = ServiceHelper.GetService<SpriteService>();
-
                 // Load Must Have items
                 if (config.Must is not null && config.Must.Count > 0)
                 {
-                    LoadItemsFromConfig(config.Must, MustHaveItems, spriteService);
+                    LoadItemsFromConfig(config.Must, MustHaveItems, _spriteService);
                     HasMustHaveItems = MustHaveItems.Count > 0;
                     SelectedFilterStats.Add(
                         new FilterStat
@@ -352,7 +352,7 @@ namespace BalatroSeedOracle.ViewModels
                 // Load Should Have items
                 if (config.Should is not null && config.Should.Count > 0)
                 {
-                    LoadItemsFromConfig(config.Should, ShouldHaveItems, spriteService);
+                    LoadItemsFromConfig(config.Should, ShouldHaveItems, _spriteService);
                     HasShouldHaveItems = ShouldHaveItems.Count > 0;
                     SelectedFilterStats.Add(
                         new FilterStat
@@ -371,7 +371,7 @@ namespace BalatroSeedOracle.ViewModels
                 // Load Must Not Have items
                 if (config.MustNot is not null && config.MustNot.Count > 0)
                 {
-                    LoadItemsFromConfig(config.MustNot, MustNotHaveItems, spriteService);
+                    LoadItemsFromConfig(config.MustNot, MustNotHaveItems, _spriteService);
                     HasMustNotHaveItems = MustNotHaveItems.Count > 0;
                     SelectedFilterStats.Add(
                         new FilterStat
@@ -514,8 +514,7 @@ namespace BalatroSeedOracle.ViewModels
 
                 if (items is not null && items.Count > 0)
                 {
-                    var spriteService = ServiceHelper.GetService<SpriteService>();
-                    LoadItemsFromConfig(items, FilterItems, spriteService);
+                    LoadItemsFromConfig(items, FilterItems, _spriteService);
                     HasFilterItems = FilterItems.Count > 0;
                 }
                 else

--- a/src/BalatroSeedOracle/ViewModels/FilterSelectionModalViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterSelectionModalViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using BalatroSeedOracle.Helpers;
 using BalatroSeedOracle.Models;
+using BalatroSeedOracle.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -10,12 +11,14 @@ namespace BalatroSeedOracle.ViewModels
 {
     public partial class FilterSelectionModalViewModel : ObservableObject, IModalBackNavigable
     {
-        // Configuration passed in constructor
-        public bool EnableSearch { get; }
-        public bool EnableEdit { get; }
-        public bool EnableCopy { get; }
-        public bool EnableDelete { get; }
-        public bool EnableAnalyze { get; }
+        private readonly IFilterService _filterService;
+
+        // Per-instance button visibility, set via Configure() after construction.
+        public bool EnableSearch { get; private set; }
+        public bool EnableEdit { get; private set; }
+        public bool EnableCopy { get; private set; }
+        public bool EnableDelete { get; private set; }
+        public bool EnableAnalyze { get; private set; }
 
         // DEBUG: Add comprehensive logging
 
@@ -100,6 +103,27 @@ namespace BalatroSeedOracle.ViewModels
         public event EventHandler<string>? DeleteConfirmationRequested;
 
         public FilterSelectionModalViewModel(
+            IFilterService filterService,
+            PaginatedFilterBrowserViewModel filterList
+        )
+        {
+            _filterService = filterService;
+            FilterList = filterList;
+
+            // Subscribe to filter selection changes
+            FilterList.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(FilterList.SelectedFilter))
+                {
+                    SelectedFilter = FilterList.SelectedFilter;
+                }
+            };
+        }
+
+        /// <summary>
+        /// Sets which action buttons should be visible. Call once right after construction.
+        /// </summary>
+        public void Configure(
             bool enableSearch = false,
             bool enableEdit = false,
             bool enableCopy = false,
@@ -113,22 +137,17 @@ namespace BalatroSeedOracle.ViewModels
             EnableDelete = enableDelete;
             EnableAnalyze = enableAnalyze;
 
+            OnPropertyChanged(nameof(EnableSearch));
+            OnPropertyChanged(nameof(EnableEdit));
+            OnPropertyChanged(nameof(EnableCopy));
+            OnPropertyChanged(nameof(EnableDelete));
+            OnPropertyChanged(nameof(EnableAnalyze));
+            OnPropertyChanged(nameof(PlaceholderText));
+
             DebugLogger.Log(
                 "FilterSelectionModalVM",
-                $"🔵 CONSTRUCTOR: EnableSearch={EnableSearch}, EnableEdit={EnableEdit}, EnableCopy={EnableCopy}"
+                $"Configured: EnableSearch={EnableSearch}, EnableEdit={EnableEdit}, EnableCopy={EnableCopy}, EnableDelete={EnableDelete}, EnableAnalyze={EnableAnalyze}"
             );
-
-            // Create child ViewModel for filter list
-            FilterList = new PaginatedFilterBrowserViewModel();
-
-            // Subscribe to filter selection changes
-            FilterList.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(FilterList.SelectedFilter))
-                {
-                    SelectedFilter = FilterList.SelectedFilter;
-                }
-            };
         }
 
         partial void OnSelectedFilterChanged(FilterBrowserItem? value)
@@ -328,13 +347,11 @@ namespace BalatroSeedOracle.ViewModels
                     $"Starting delete for filter: {filterNameToDelete} ({filterIdToDelete})"
                 );
 
-                // Get FilterService to perform the deletion
-                var filterService = ServiceHelper.GetRequiredService<Services.IFilterService>();
                 var filtersDir = AppPaths.FiltersDir;
                 var filterPath = System.IO.Path.Combine(filtersDir, $"{filterIdToDelete}.json");
 
                 // Perform deletion (this also removes from cache)
-                var deleted = await filterService.DeleteFilterAsync(filterPath);
+                var deleted = await _filterService.DeleteFilterAsync(filterPath);
 
                 if (!deleted)
                 {

--- a/src/BalatroSeedOracle/ViewModels/FilterTabs/ConfigureFilterTabViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterTabs/ConfigureFilterTabViewModel.cs
@@ -23,6 +23,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
     public partial class ConfigureFilterTabViewModel : ObservableObject
     {
         private readonly FiltersModalViewModel? _parentViewModel;
+        private readonly IConfigurationService? _configurationService;
 
         // Auto-save debouncing
         private CancellationTokenSource? _autoSaveCts;
@@ -155,9 +156,13 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
         // Item configurations
         public Dictionary<string, ItemConfig> ItemConfigs { get; }
 
-        public ConfigureFilterTabViewModel(FiltersModalViewModel? parentViewModel = null)
+        public ConfigureFilterTabViewModel(
+            FiltersModalViewModel? parentViewModel = null,
+            IConfigurationService? configurationService = null
+        )
         {
             _parentViewModel = parentViewModel;
+            _configurationService = configurationService;
 
             // Subscribe to parent's property changes
             if (_parentViewModel is not null)
@@ -1156,7 +1161,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 }
 
                 var config = _parentViewModel.BuildConfigFromCurrentState();
-                var configService = ServiceHelper.GetService<IConfigurationService>();
+                var configService = _configurationService;
 
                 if (configService is null)
                     return;

--- a/src/BalatroSeedOracle/ViewModels/FilterTabs/JsonEditorTabViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterTabs/JsonEditorTabViewModel.cs
@@ -31,6 +31,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
         };
 
         private readonly FiltersModalViewModel? _parentViewModel;
+        private readonly FilterSerializationService? _serializationService;
 
         public event EventHandler<string>? CopyToClipboardRequested;
 
@@ -51,9 +52,13 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 ? $"📄 {_parentViewModel.FilterName}.json"
                 : "📄 filter.json";
 
-        public JsonEditorTabViewModel(FiltersModalViewModel? parentViewModel = null)
+        public JsonEditorTabViewModel(
+            FiltersModalViewModel? parentViewModel = null,
+            FilterSerializationService? serializationService = null
+        )
         {
             _parentViewModel = parentViewModel;
+            _serializationService = serializationService;
 
             // Set default JSON content
             JsonContent = GetDefaultJsonContent();
@@ -128,9 +133,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 // No separate MustNot collection needed
 
                 // Update JSON content silently using FilterSerializationService for proper formatting
-                var serializationService = ServiceHelper.GetService<FilterSerializationService>();
                 JsonContent =
-                    serializationService?.SerializeConfig(config)
+                    _serializationService?.SerializeConfig(config)
                     ?? JsonSerializer.Serialize(config, SerializeOptions);
 
                 // Silent status update (no user-visible message)

--- a/src/BalatroSeedOracle/ViewModels/FilterTabs/SaveFilterTabViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterTabs/SaveFilterTabViewModel.cs
@@ -22,6 +22,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
         private readonly IFilterService _filterService;
         private readonly FiltersModalViewModel _parentViewModel;
         private readonly IPlatformServices _platformServices;
+        private readonly FilterSerializationService? _serializationService;
+        private readonly SearchManager? _searchManager;
 
         public event EventHandler<string>? CopyToClipboardRequested;
 
@@ -217,15 +219,18 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
             IConfigurationService configurationService,
             IFilterService filterService,
             IPlatformServices platformServices,
-            NotificationService? notificationService = null
+            NotificationService? notificationService = null,
+            FilterSerializationService? serializationService = null,
+            SearchManager? searchManager = null
         )
         {
             _parentViewModel = parentViewModel;
             _configurationService = configurationService;
             _filterService = filterService;
             _platformServices = platformServices;
-            _notificationService =
-                notificationService ?? ServiceHelper.GetService<NotificationService>();
+            _notificationService = notificationService;
+            _serializationService = serializationService;
+            _searchManager = searchManager;
 
             // PRE-FILL filter name and description if available
             PreFillFilterData();
@@ -361,10 +366,12 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                     return;
                 }
 
-                // Use custom serializer to include mode and preserve score formatting
-                var userProfileService = ServiceHelper.GetService<UserProfileService>();
-                var serializer = new FilterSerializationService(userProfileService!);
-                var json = serializer.SerializeConfig(config);
+                if (_serializationService is null)
+                {
+                    UpdateStatus("Export not available (FilterSerializationService missing)", true);
+                    return;
+                }
+                var json = _serializationService.SerializeConfig(config);
 
                 var exportFileName = $"{NormalizeFilterName(config.Name ?? "filter")}.json";
 
@@ -637,9 +644,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 };
 
                 // Start search via SearchManager and wait for results
-                var searchManager =
-                    ServiceHelper.GetService<BalatroSeedOracle.Services.SearchManager>();
-                if (searchManager is null)
+                if (_searchManager is null)
                 {
                     IsTestRunning = false;
                     ShowTestError = true;
@@ -647,6 +652,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                     UpdateStatus("SearchManager not available", true);
                     return;
                 }
+                var searchManager = _searchManager;
 
                 // Run quick search with in-memory config (no file I/O!)
                 UpdateStatus(

--- a/src/BalatroSeedOracle/ViewModels/FilterTabs/ValidateFilterTabViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterTabs/ValidateFilterTabViewModel.cs
@@ -25,6 +25,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
         private readonly FiltersModalViewModel _parentViewModel;
         private readonly ClauseConversionService _clauseConversionService;
         private readonly IPlatformServices _platformServices;
+        private readonly FilterSerializationService? _serializationService;
+        private readonly SearchManager? _searchManager;
 
         public event EventHandler<string>? CopyToClipboardRequested;
 
@@ -115,7 +117,9 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
             FiltersModalViewModel parentViewModel,
             IConfigurationService configurationService,
             IFilterService filterService,
-            IPlatformServices platformServices
+            IPlatformServices platformServices,
+            FilterSerializationService? serializationService = null,
+            SearchManager? searchManager = null
         )
         {
             _parentViewModel = parentViewModel;
@@ -123,6 +127,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
             _filterService = filterService;
             _clauseConversionService = new ClauseConversionService();
             _platformServices = platformServices;
+            _serializationService = serializationService;
+            _searchManager = searchManager;
 
             // PRE-FILL filter name and description if available
             PreFillFilterData();
@@ -689,10 +695,12 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                     return Task.CompletedTask;
                 }
 
-                // Serialize to JSON
-                var userProfileService = ServiceHelper.GetService<UserProfileService>();
-                var serializer = new FilterSerializationService(userProfileService!);
-                var json = serializer.SerializeConfig(config);
+                if (_serializationService is null)
+                {
+                    UpdateStatus("Copy not available (FilterSerializationService missing)", true);
+                    return Task.CompletedTask;
+                }
+                var json = _serializationService.SerializeConfig(config);
 
                 // Copy to clipboard via event
                 CopyToClipboardRequested?.Invoke(this, json);
@@ -757,10 +765,12 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                     return;
                 }
 
-                // Use custom serializer to include mode and preserve score formatting
-                var userProfileService = ServiceHelper.GetService<UserProfileService>();
-                var serializer = new FilterSerializationService(userProfileService!);
-                var json = serializer.SerializeConfig(config);
+                if (_serializationService is null)
+                {
+                    UpdateStatus("Export not available (FilterSerializationService missing)", true);
+                    return;
+                }
+                var json = _serializationService.SerializeConfig(config);
 
                 var exportFileName = $"{config.Name}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
 
@@ -855,9 +865,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 var deckName = GetDeckName(_parentViewModel.SelectedDeckIndex);
                 var stakeName = GetStakeName(_parentViewModel.SelectedStakeIndex);
 
-                var searchManager =
-                    ServiceHelper.GetService<BalatroSeedOracle.Services.SearchManager>();
-                if (searchManager is null)
+                if (_searchManager is null)
                 {
                     IsTestRunning = false;
                     IsLiveSearchActive = false;
@@ -866,6 +874,7 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                     UpdateStatus("SearchManager not available", true);
                     return;
                 }
+                var searchManager = _searchManager;
 
                 // PHASE 1: Ultra-quick sanity check (1 batch = 35 seeds)
                 LiveSearchStatus = "Phase 1: Quick sanity check (35 seeds)...";

--- a/src/BalatroSeedOracle/ViewModels/FilterTabs/VisualBuilderTabViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterTabs/VisualBuilderTabViewModel.cs
@@ -34,6 +34,9 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
     public partial class VisualBuilderTabViewModel : ObservableObject
     {
         private readonly FiltersModalViewModel? _parentViewModel;
+        private readonly FavoritesService? _favoritesService;
+        private readonly IConfigurationService? _configurationService;
+        private readonly IFilterService? _filterService;
 
         // Auto-save debouncing
         private CancellationTokenSource? _autoSaveCts;
@@ -387,9 +390,17 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
         // Item configurations
         public Dictionary<string, ItemConfig> ItemConfigs { get; }
 
-        public VisualBuilderTabViewModel(FiltersModalViewModel? parentViewModel = null)
+        public VisualBuilderTabViewModel(
+            FiltersModalViewModel? parentViewModel = null,
+            FavoritesService? favoritesService = null,
+            IConfigurationService? configurationService = null,
+            IFilterService? filterService = null
+        )
         {
             _parentViewModel = parentViewModel;
+            _favoritesService = favoritesService;
+            _configurationService = configurationService;
+            _filterService = filterService;
 
             // Subscribe to parent's property changes to update FilterName and edit mode
             if (_parentViewModel is not null)
@@ -2091,8 +2102,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
 
                 // Mark favorite items AFTER all items are loaded with their proper categories
                 // This ensures favorited items appear in BOTH Favorites AND their original category
-                var favoritesService = ServiceHelper.GetService<FavoritesService>();
-                var favoriteNames = favoritesService?.GetFavoriteItems() ?? new List<string>();
+                var favoriteNames = (_favoritesService ?? FavoritesService.Instance)
+                    ?.GetFavoriteItems() ?? new List<string>();
 
                 foreach (var favoriteName in favoriteNames)
                 {
@@ -2625,8 +2636,8 @@ namespace BalatroSeedOracle.ViewModels.FilterTabs
                 var config = _parentViewModel.BuildConfigFromCurrentState();
 
                 // Get configuration service
-                var configService = ServiceHelper.GetService<IConfigurationService>();
-                var filterService = ServiceHelper.GetService<IFilterService>();
+                var configService = _configurationService;
+                var filterService = _filterService;
 
                 if (configService is null || filterService is null)
                 {

--- a/src/BalatroSeedOracle/ViewModels/FiltersModalViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FiltersModalViewModel.cs
@@ -36,6 +36,10 @@ namespace BalatroSeedOracle.ViewModels
         private readonly IFilterService _filterService;
         private readonly IPlatformServices _platformServices;
         private readonly NotificationService? _notificationService;
+        private readonly UserProfileService? _userProfileService;
+        private readonly SearchManager? _searchManager;
+        private readonly FilterSerializationService? _serializationService;
+        private readonly Func<ValidateFilterTabViewModel>? _validateTabFactory;
 
         // ===== CORE STATE (using [ObservableProperty] for automatic INotifyPropertyChanged) =====
         [ObservableProperty]
@@ -147,14 +151,21 @@ namespace BalatroSeedOracle.ViewModels
             IConfigurationService configurationService,
             IFilterService filterService,
             IPlatformServices platformServices,
-            NotificationService? notificationService = null
+            NotificationService? notificationService = null,
+            UserProfileService? userProfileService = null,
+            SearchManager? searchManager = null,
+            FilterSerializationService? serializationService = null,
+            Func<ValidateFilterTabViewModel>? validateTabFactory = null
         )
         {
             _configurationService = configurationService;
             _filterService = filterService;
             _platformServices = platformServices;
-            _notificationService =
-                notificationService ?? ServiceHelper.GetService<NotificationService>();
+            _notificationService = notificationService;
+            _userProfileService = userProfileService;
+            _searchManager = searchManager;
+            _serializationService = serializationService;
+            _validateTabFactory = validateTabFactory;
 
             _itemCategories = InitializeItemCategories();
 
@@ -343,8 +354,7 @@ namespace BalatroSeedOracle.ViewModels
                     BsoLogger.Log("FiltersModalViewModel", $"✅ Filter saved: {CurrentFilterPath}");
 
                     // Show notification
-                    var notificationService = ServiceHelper.GetService<NotificationService>();
-                    notificationService?.ShowSuccess(
+                    _notificationService?.ShowSuccess(
                         "Filter Saved",
                         $"Filter '{FilterName}' saved successfully",
                         TimeSpan.FromSeconds(3)
@@ -394,10 +404,9 @@ namespace BalatroSeedOracle.ViewModels
             try
             {
                 var filterName = Path.GetFileNameWithoutExtension(CurrentFilterPath);
-                var searchManager = ServiceHelper.GetService<SearchManager>();
-                if (searchManager is not null)
+                if (_searchManager is not null)
                 {
-                    searchManager.StopSearchesForFilter(filterName);
+                    _searchManager.StopSearchesForFilter(filterName);
                     BsoLogger.Log(
                         "FiltersModalViewModel",
                         $"Stopped searches for filter: {filterName}"
@@ -915,8 +924,7 @@ namespace BalatroSeedOracle.ViewModels
         /// </summary>
         public Motely.Filters.Jaml.JamlRootDocument BuildConfigFromCurrentState()
         {
-            var userProfileService = ServiceHelper.GetService<UserProfileService>();
-            var author = userProfileService?.GetAuthorName() ?? "Unknown";
+            var author = _userProfileService?.GetAuthorName() ?? "Unknown";
 
             var config = new Motely.Filters.Jaml.JamlRootDocument
             {
@@ -1440,23 +1448,24 @@ namespace BalatroSeedOracle.ViewModels
             JamlEditorTab = jamlEditorViewModel; // Store reference
             TabItems.Add(new TabItemViewModel("JAML EDITOR", jamlEditorTab));
 
-            // Save Filter tab
-            var configService =
-                ServiceHelper.GetService<IConfigurationService>()
-                ?? throw new InvalidOperationException("IConfigurationService not available");
-            var filterService =
-                ServiceHelper.GetService<IFilterService>()
-                ?? throw new InvalidOperationException("IFilterService not available");
-            var userProfileService =
-                ServiceHelper.GetService<UserProfileService>()
-                ?? throw new InvalidOperationException("UserProfileService not available");
-            var platformServices = ServiceHelper.GetRequiredService<IPlatformServices>();
-            var validateFilterViewModel = new FilterTabs.ValidateFilterTabViewModel(
-                this,
-                configService,
-                filterService,
-                platformServices
-            );
+            // Save Filter tab - resolve through DI factory so dependencies stay in one place
+            ValidateFilterTabViewModel validateFilterViewModel;
+            if (_validateTabFactory is not null)
+            {
+                validateFilterViewModel = _validateTabFactory();
+            }
+            else
+            {
+                // Fallback: construct directly from the services already injected here.
+                validateFilterViewModel = new ValidateFilterTabViewModel(
+                    this,
+                    _configurationService,
+                    _filterService,
+                    _platformServices,
+                    _serializationService,
+                    _searchManager
+                );
+            }
             var validateFilterTab = new Components.FilterTabs.ValidateFilterTab
             {
                 DataContext = validateFilterViewModel,

--- a/src/BalatroSeedOracle/ViewModels/PaginatedFilterBrowserViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/PaginatedFilterBrowserViewModel.cs
@@ -19,6 +19,8 @@ namespace BalatroSeedOracle.ViewModels
     {
         private const int ITEMS_PER_PAGE = 10;
 
+        private readonly IFilterCacheService _filterCacheService;
+        private readonly UserProfileService? _userProfileService;
         private readonly List<FilterBrowserItem> _allFilters = [];
 
         [ObservableProperty]
@@ -62,8 +64,13 @@ namespace BalatroSeedOracle.ViewModels
         // Events
         public event EventHandler<FilterBrowserItem>? FilterSelected;
 
-        public PaginatedFilterBrowserViewModel()
+        public PaginatedFilterBrowserViewModel(
+            IFilterCacheService filterCacheService,
+            UserProfileService? userProfileService = null
+        )
         {
+            _filterCacheService = filterCacheService;
+            _userProfileService = userProfileService;
             LoadFilters();
         }
 
@@ -118,9 +125,7 @@ namespace BalatroSeedOracle.ViewModels
             {
                 Name = "New Filter",
                 Description = "Created with Filter Designer",
-                Author =
-                    ServiceHelper.GetService<Services.UserProfileService>()?.GetAuthorName()
-                    ?? "Unknown",
+                Author = _userProfileService?.GetAuthorName() ?? "Unknown",
                 DateCreated = DateTime.UtcNow.ToString("o"),
                 Must =
                     new System.Collections.Generic.List<Motely.Filters.Jaml.JamlClauseUnion>(),
@@ -169,54 +174,14 @@ namespace BalatroSeedOracle.ViewModels
             {
                 _allFilters.Clear();
 
-                // Try to use the cache service first for performance
-                var filterCache = ServiceHelper.GetService<Services.IFilterCacheService>();
-                if (filterCache is not null)
-                {
-                    DebugLogger.Log(
-                        "PaginatedFilterBrowserViewModel",
-                        $"Loading filters from cache ({filterCache.Count} cached)"
-                    );
-
-                    var cachedFilters = filterCache.GetAllFilters();
-                    foreach (var cached in cachedFilters)
-                    {
-                        var filterItem = ConvertCachedFilterToBrowserItem(cached);
-                        if (filterItem is not null)
-                        {
-                            _allFilters.Add(filterItem);
-                        }
-                    }
-
-                    UpdateCurrentPage();
-                    return;
-                }
-
-                // Fallback to disk loading if cache not available
                 DebugLogger.Log(
                     "PaginatedFilterBrowserViewModel",
-                    "Cache service not available, loading from disk"
+                    $"Loading filters from cache ({_filterCacheService.Count} cached)"
                 );
 
-                var filtersDir = AppPaths.FiltersDir;
-                if (!Directory.Exists(filtersDir))
+                foreach (var cached in _filterCacheService.GetAllFilters())
                 {
-                    UpdateCurrentPage();
-                    return;
-                }
-
-                // Load both .json and .jaml filter files
-                var jsonFiles = Directory.GetFiles(filtersDir, "*.json");
-                var jamlFiles = Directory.GetFiles(filtersDir, "*.jaml");
-                var filterFiles = jsonFiles
-                    .Concat(jamlFiles)
-                    .Where(f => Path.GetFileName(f) != "_UNSAVED_CREATION.json") // Skip temp files
-                    .OrderByDescending(File.GetLastWriteTime)
-                    .ToList();
-
-                foreach (var filePath in filterFiles)
-                {
-                    var filterItem = LoadFilterBrowserItem(filePath);
+                    var filterItem = ConvertCachedFilterToBrowserItem(cached);
                     if (filterItem is not null)
                     {
                         _allFilters.Add(filterItem);
@@ -543,11 +508,9 @@ namespace BalatroSeedOracle.ViewModels
 
         public void RefreshFilters()
         {
-            // CRITICAL FIX: Rescan filesystem FIRST to remove deleted filters from cache
-            var filterCache = ServiceHelper.GetService<IFilterCacheService>();
-            filterCache?.RefreshCache();
-
-            // THEN reload from refreshed cache
+            // Rescan filesystem first so deleted filters drop out of the cache,
+            // then reload our list from the refreshed cache.
+            _filterCacheService.RefreshCache();
             LoadFilters();
         }
     }

--- a/src/BalatroSeedOracle/ViewModels/SearchWidgetViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/SearchWidgetViewModel.cs
@@ -44,12 +44,14 @@ namespace BalatroSeedOracle.ViewModels
         private string _progressText = "0%";
 
         private readonly NotificationService? _notificationService;
+        private readonly UserProfileService? _userProfileService;
 
         public SearchWidgetViewModel(
             ActiveSearchContext searchInstance,
             SpriteService spriteService,
             WidgetPositionService? widgetPositionService = null,
-            NotificationService? notificationService = null
+            NotificationService? notificationService = null,
+            UserProfileService? userProfileService = null
         )
             : base(widgetPositionService)
         {
@@ -57,8 +59,8 @@ namespace BalatroSeedOracle.ViewModels
                 searchInstance ?? throw new ArgumentNullException(nameof(searchInstance));
             _spriteService =
                 spriteService ?? throw new ArgumentNullException(nameof(spriteService));
-            _notificationService =
-                notificationService ?? ServiceHelper.GetService<NotificationService>();
+            _notificationService = notificationService;
+            _userProfileService = userProfileService;
 
             // Initialize from SearchInstance
             FilterName = _searchInstance.FilterName ?? "Search";
@@ -243,8 +245,7 @@ namespace BalatroSeedOracle.ViewModels
         {
             try
             {
-                var profileService = ServiceHelper.GetService<UserProfileService>();
-                if (profileService is null)
+                if (_userProfileService is null)
                 {
                     DebugLogger.LogError(
                         "SearchWidgetViewModel",
@@ -253,7 +254,7 @@ namespace BalatroSeedOracle.ViewModels
                     return;
                 }
 
-                var profile = profileService.GetProfile();
+                var profile = _userProfileService.GetProfile();
 
                 // Find existing saved widget or create new
                 var saved = profile.SavedSearchWidgets.FirstOrDefault(w =>
@@ -273,7 +274,7 @@ namespace BalatroSeedOracle.ViewModels
                 saved.ZIndexOffset = 0; // Will use BaseWidgetViewModel's _zIndexOffset if needed
                 saved.LastUsed = DateTime.UtcNow;
 
-                profileService.SaveProfile(profile);
+                _userProfileService.SaveProfile(profile);
 
                 DebugLogger.Log(
                     "SearchWidgetViewModel",
@@ -297,14 +298,13 @@ namespace BalatroSeedOracle.ViewModels
             try
             {
                 // Remove from saved widgets
-                var profileService = ServiceHelper.GetService<UserProfileService>();
-                if (profileService is not null)
+                if (_userProfileService is not null)
                 {
-                    var profile = profileService.GetProfile();
+                    var profile = _userProfileService.GetProfile();
                     profile.SavedSearchWidgets.RemoveAll(w =>
                         w.SearchInstanceId == SearchInstanceId
                     );
-                    profileService.SaveProfile(profile);
+                    _userProfileService.SaveProfile(profile);
 
                     DebugLogger.Log(
                         "SearchWidgetViewModel",

--- a/src/BalatroSeedOracle/Views/BalatroMainMenu.axaml.cs
+++ b/src/BalatroSeedOracle/Views/BalatroMainMenu.axaml.cs
@@ -227,15 +227,19 @@ namespace BalatroSeedOracle.Views
             _previousModalContent = null;
             _previousModalTitle = null;
 
-            var filterSelectionVM = new FilterSelectionModalViewModel(
+            var configurationService = App.GetService<IConfigurationService>()
+                ?? throw new InvalidOperationException("IConfigurationService not registered");
+            var filterService = App.GetService<IFilterService>()
+                ?? throw new InvalidOperationException("IFilterService not registered");
+            var filterSelectionVM = App.GetService<FilterSelectionModalViewModel>()
+                ?? throw new InvalidOperationException("FilterSelectionModalViewModel not registered");
+            filterSelectionVM.Configure(
                 enableSearch: true,
                 enableEdit: true,
                 enableCopy: false,
                 enableDelete: false,
                 enableAnalyze: false
             );
-            var configurationService = ServiceHelper.GetRequiredService<IConfigurationService>();
-            var filterService = ServiceHelper.GetRequiredService<IFilterService>();
             var filterSelectionModal = new FilterSelectionModal(
                 filterSelectionVM,
                 configurationService,
@@ -421,15 +425,19 @@ namespace BalatroSeedOracle.Views
         public void ShowFiltersModal()
         {
             // Create FilterSelectionModal with Edit/Copy/Delete actions enabled
-            var filterSelectionVM = new FilterSelectionModalViewModel(
+            var configurationService = App.GetService<IConfigurationService>()
+                ?? throw new InvalidOperationException("IConfigurationService not registered");
+            var filterService = App.GetService<IFilterService>()
+                ?? throw new InvalidOperationException("IFilterService not registered");
+            var filterSelectionVM = App.GetService<FilterSelectionModalViewModel>()
+                ?? throw new InvalidOperationException("FilterSelectionModalViewModel not registered");
+            filterSelectionVM.Configure(
                 enableSearch: false,
                 enableEdit: true,
                 enableCopy: true,
                 enableDelete: true,
                 enableAnalyze: false
             );
-            var configurationService = ServiceHelper.GetRequiredService<IConfigurationService>();
-            var filterService = ServiceHelper.GetRequiredService<IFilterService>();
             var filterSelectionModal = new FilterSelectionModal(
                 filterSelectionVM,
                 configurationService,
@@ -1982,17 +1990,20 @@ namespace BalatroSeedOracle.Views
                     return;
                 }
 
-                var platformServices = ServiceHelper.GetService<IPlatformServices>();
+                var platformServices = App.GetService<IPlatformServices>();
                 if (platformServices?.SupportsResultsGrid == true)
                 {
                     // Create SearchWidget with proper ViewModel (works on all platforms)
                     var spriteService = SpriteService.Instance;
-                    var notificationService = ServiceHelper.GetService<NotificationService>();
+                    var notificationService = App.GetService<NotificationService>();
+                    var userProfileService = App.GetService<UserProfileService>();
+                    var widgetPositionService = App.GetService<WidgetPositionService>();
                     var viewModel = new SearchWidgetViewModel(
                         searchInstance,
                         spriteService,
-                        null,
-                        notificationService
+                        widgetPositionService,
+                        notificationService,
+                        userProfileService
                     );
                     var searchWidget = new Components.Widgets.SearchWidget
                     {

--- a/src/BalatroSeedOracle/Views/Modals/FilterSelectionModal.axaml.cs
+++ b/src/BalatroSeedOracle/Views/Modals/FilterSelectionModal.axaml.cs
@@ -568,9 +568,12 @@ namespace BalatroSeedOracle.Views.Modals
 
                 var configurationService =
                     _configurationService
-                    ?? ServiceHelper.GetRequiredService<IConfigurationService>();
+                    ?? App.GetService<IConfigurationService>()
+                    ?? throw new InvalidOperationException("IConfigurationService not registered");
                 var filterService =
-                    _filterService ?? ServiceHelper.GetRequiredService<IFilterService>();
+                    _filterService
+                    ?? App.GetService<IFilterService>()
+                    ?? throw new InvalidOperationException("IFilterService not registered");
                 var baseName = !string.IsNullOrWhiteSpace(config.Name)
                     ? config.Name
                     : Path.GetFileNameWithoutExtension(file.Name);


### PR DESCRIPTION
## Summary

Continues the static service-locator removal started in #24 (services). This phase eliminates **all** `ServiceHelper.GetService` / `GetRequiredService` calls from the `ViewModels/` tree, moving the dependencies to constructor injection so the VMs are pure logic units again.

The `Helpers/ServiceHelper.cs` static class itself is **not** deleted yet — the remaining call sites (Behaviors, Converters, code-behind `.axaml.cs`, Desktop project) are separate phases. After every phase lands, `ServiceHelper.cs` can be removed in a final cleanup commit.

## ViewModels updated

- **`FilterListViewModel`** — `IFilterCacheService` + `SpriteService` ctor-injected.
- **`PaginatedFilterBrowserViewModel`** — `IFilterCacheService` + `UserProfileService` ctor-injected; deletes the dead "fallback to disk loading" branch since the cache service is now always available.
- **`FilterSelectionModalViewModel`** — `IFilterService` + `PaginatedFilterBrowserViewModel` ctor-injected. The five `enable*` booleans become a `Configure(...)` call used right after DI resolution.
- **`BaseWidgetViewModel`** — drops two `ServiceHelper.GetService<WidgetPositionService>` duplicates and reuses the already-injected `_widgetPositionService` field.
- **`SearchWidgetViewModel`** — `UserProfileService` becomes an optional ctor param; the `?? ServiceHelper.GetService` fallback on `NotificationService` is gone.
- **`FiltersModalViewModel`** — `UserProfileService`, `SearchManager`, `FilterSerializationService`, and a `Func<ValidateFilterTabViewModel>` factory are ctor-injected. `InitializeTabs()` no longer does service location to build `ValidateFilterTabViewModel`.
- **`JsonEditorTabViewModel`** — `FilterSerializationService` ctor-injected (was `ServiceHelper.GetService<FilterSerializationService>()` mid-method).
- **`SaveFilterTabViewModel` / `ValidateFilterTabViewModel`** — `FilterSerializationService` + `SearchManager` ctor-injected; export/test paths no longer `new FilterSerializationService(userProfileService!)`.
- **`ConfigureFilterTabViewModel`** — `IConfigurationService` ctor-injected.
- **`VisualBuilderTabViewModel`** — `FavoritesService` + `IConfigurationService` + `IFilterService` ctor-injected (FavoritesService still falls back to `.Instance` to mirror #24's bootstrap design).
- **`BalatroMainMenuViewModel`** — uses the already-injected `SearchModalViewModel` property instead of resolving it; takes a `Func<FilterSelectionModalViewModel>` so `SeedSearch` can build a fresh selection modal without `ServiceHelper`.

## Call sites

- `Components/FilterSelectorControl.axaml.cs` / `Components/PaginatedFilterBrowser.axaml.cs` code-behind now resolve their VMs through `App.GetService<T>()` (DI) instead of `new`.
- `BalatroMainMenu.ShowSearchModal` / `ShowFiltersModal` pull `FilterSelectionModalViewModel` from DI and call `Configure(...)`.
- `Helpers/ModalHelper.ShowFilterSelectionModal` does the same. The temp-filter `Author` lookup is now `App.GetService` instead of `ServiceHelper`.
- `BalatroMainMenu.ShowSearchDesktopIcon` builds `SearchWidgetViewModel` with explicit `UserProfileService` + `WidgetPositionService` from DI (was `ServiceHelper` + `null` + fallback inside the ctor).
- `Views/Modals/FilterSelectionModal.axaml.cs::ImportFilterFile` falls back to `App.GetService` rather than `ServiceHelper` when the parameterless XAML ctor is used.

## DI registration

`Extensions/ServiceCollectionExtensions.cs` is updated to wire all the new ctor parameters. `FilterListViewModel`, `PaginatedFilterBrowserViewModel`, `FilterSelectionModalViewModel`, every `FilterTabs/*ViewModel`, `FiltersModalViewModel`, and `BalatroMainMenuViewModel` now get proper factory registrations.

## Non-goals (deferred to later phases)

- `Behaviors/` (CardDragBehavior, DraggableWidgetBehavior, PlaySfxOnValueChangeBehavior)
- `Converters/SpriteConverters.cs` (15 call sites — XAML-attached, harder to inject into)
- `Views/*.axaml.cs` code-behind (BalatroMainMenu god class, MainWindow, ToolsModal, etc.)
- `BalatroSeedOracle.Desktop/` (widgets that XAML-instantiate themselves)
- `Services/*.cs` — already done in #24

Once those phases land, `Helpers/ServiceHelper.cs` and `App.GetService<T>` can be removed entirely.

## Test plan

`dotnet` is not available in this remote execution environment, so the build was **not** run locally. The refactor is conservative: all changes are constructor-parameter additions, internal field reuse, or DI-resolution swaps that preserve the original control flow. Please run locally / via CI before merging:

- [ ] `dotnet build src/BalatroSeedOracle.Desktop/BalatroSeedOracle.Desktop.csproj -c Release` — clean
- [ ] App launches; main menu renders
- [ ] **SeedSearch** flow: click Seed Search → filter selector lists filters → SEARCH advances to Search modal (exercises `BalatroMainMenuViewModel._filterSelectionFactory` + `FilterSelectionModalViewModel.Configure`)
- [ ] **ShowFiltersModal** flow: click Filters → list renders → Edit/Copy/Delete buttons visible (exercises second `Configure` path)
- [ ] **FilterSelector** component renders a paginated filter list (exercises `App.GetService<FilterListViewModel>`)
- [ ] **Visual Builder tab** loads with favorites marked correctly (exercises `_favoritesService` injection)
- [ ] **Validate Filter tab** test/export/copy JSON paths all work (exercises `FilterSerializationService` + `SearchManager` injection)
- [ ] **Save Filter tab** export path works
- [ ] Save a filter → notification appears (exercises injected `NotificationService` in `FiltersModalViewModel.SaveCurrentFilter`)
- [ ] Start a search → minimize widget → close & reopen app → widget reappears and saves on move (exercises `SearchWidgetViewModel` injected `UserProfileService`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKZKQsyYYkdY6VZNzen2WF)_