### PR TITLE
fix: resolve DaylatroHighScoreService via DI

### DIFF
--- a/src/BalatroSeedOracle/Components/Widgets/DailyRitualWidget.axaml.cs
+++ b/src/BalatroSeedOracle/Components/Widgets/DailyRitualWidget.axaml.cs
@@ -16,7 +16,8 @@ namespace BalatroSeedOracle.Components
         {
             // Initialize ViewModel
             ViewModel = new DailyRitualWidgetViewModel(
-                DaylatroHighScoreService.Instance,
+                App.GetService<DaylatroHighScoreService>()
+                    ?? throw new InvalidOperationException("DaylatroHighScoreService not available"),
                 App.GetService<UserProfileService>()
                     ?? throw new InvalidOperationException("UserProfileService not available"),
                 App.GetService<FilterConfigurationService>()

--- a/src/BalatroSeedOracle/Components/Widgets/DayLatroWidget.axaml.cs
+++ b/src/BalatroSeedOracle/Components/Widgets/DayLatroWidget.axaml.cs
@@ -22,7 +22,8 @@ namespace BalatroSeedOracle.Components
         {
             // Initialize ViewModel with dependency injection
             ViewModel = new DayLatroWidgetViewModel(
-                DaylatroHighScoreService.Instance,
+                App.GetService<DaylatroHighScoreService>()
+                    ?? throw new InvalidOperationException("DaylatroHighScoreService not available"),
                 App.GetService<UserProfileService>()
                     ?? throw new InvalidOperationException("UserProfileService not available")
             );


### PR DESCRIPTION
## Summary
- Fix CS0117 build errors in `DailyRitualWidget.axaml.cs` and `DayLatroWidget.axaml.cs`: `DaylatroHighScoreService.Instance` does not exist — the service is registered as a DI singleton in `ServiceCollectionExtensions`, so resolve via `App.GetService<DaylatroHighScoreService>()` like the sibling services in the same constructors.

## Build / Run
- `dotnet build src/BalatroSeedOracle.Desktop/BalatroSeedOracle.Desktop.csproj -c Debug -p:AvaloniaUILicenseDisableTask=true` → succeeds.
- App launches and reaches "Application initialization complete" under Xvfb. Runtime hits the Avalonia commercial-license check on `TreeDataGrid`/`Markdown` during sprite preload because the sandbox can't reach `api.avaloniaui.net`; that's unrelated to this fix.

## Test plan
- [ ] `dotnet build` on a machine with Avalonia license server reachable
- [ ] Launch desktop app and confirm the two widgets (DayLatro, DailyRitual) initialize without throwing

https://claude.ai/code/session_01XzstPkBzxNoXR4mUHDUoA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzstPkBzxNoXR4mUHDUoA3)_