### PR TITLE
Modernize VM change-notification to source-generator attributes

### DIFF
--- a/src/BalatroSeedOracle/ViewModels/AnalyzeModalViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/AnalyzeModalViewModel.cs
@@ -18,24 +18,35 @@ namespace BalatroSeedOracle.ViewModels
         private readonly UserProfileService _userProfileService;
 
         [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(AnalyzeSeedCommand))]
         private string _seedInput = "";
 
         [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(AnalyzeSeedCommand))]
         private bool _isAnalyzing = false;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsSettingsTabActive))]
+        [NotifyPropertyChangedFor(nameof(IsAnalyzerTabActive))]
+        [NotifyPropertyChangedFor(nameof(SettingsTabVisible))]
+        [NotifyPropertyChangedFor(nameof(AnalyzerTabVisible))]
+        [NotifyPropertyChangedFor(nameof(TriangleColumn))]
         private AnalyzeModalTab _activeTab = AnalyzeModalTab.Settings;
 
         [ObservableProperty]
         private bool _showPlaceholder = true;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(SelectedDeck))]
         private int _deckIndex = 0;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(SelectedStake))]
         private int _stakeIndex = 0;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(HasAnalysisResults))]
+        [NotifyPropertyChangedFor(nameof(AnalysisHeader))]
         private SeedAnalysisModel? _currentAnalysis;
 
         public AnalyzeModalViewModel(
@@ -61,7 +72,7 @@ namespace BalatroSeedOracle.ViewModels
         public MotelyStake SelectedStake => (MotelyStake)StakeIndex;
 
         public bool HasAnalysisResults =>
-            CurrentAnalysis is not null && !string.IsNullOrEmpty(CurrentAnalysis.Error) == false;
+            CurrentAnalysis is not null && string.IsNullOrEmpty(CurrentAnalysis.Error);
         public string AnalysisHeader =>
             CurrentAnalysis is not null
                 ? $"Seed: {CurrentAnalysis.Seed} | Deck: {CurrentAnalysis.Deck} | Stake: {CurrentAnalysis.Stake}"
@@ -73,40 +84,12 @@ namespace BalatroSeedOracle.ViewModels
 
         #region Generated Property Changed Methods
 
+        // Dependent display properties and command CanExecute notifications are wired
+        // declaratively via [NotifyPropertyChangedFor] / [NotifyCanExecuteChangedFor]
+        // on the backing fields above.
         partial void OnSeedInputChanged(string value)
         {
-            AnalyzeSeedCommand.NotifyCanExecuteChanged();
             UpdatePlaceholderVisibility();
-        }
-
-        partial void OnIsAnalyzingChanged(bool value)
-        {
-            AnalyzeSeedCommand.NotifyCanExecuteChanged();
-        }
-
-        partial void OnActiveTabChanged(AnalyzeModalTab value)
-        {
-            OnPropertyChanged(nameof(IsSettingsTabActive));
-            OnPropertyChanged(nameof(IsAnalyzerTabActive));
-            OnPropertyChanged(nameof(SettingsTabVisible));
-            OnPropertyChanged(nameof(AnalyzerTabVisible));
-            OnPropertyChanged(nameof(TriangleColumn));
-        }
-
-        partial void OnDeckIndexChanged(int value)
-        {
-            OnPropertyChanged(nameof(SelectedDeck));
-        }
-
-        partial void OnStakeIndexChanged(int value)
-        {
-            OnPropertyChanged(nameof(SelectedStake));
-        }
-
-        partial void OnCurrentAnalysisChanged(SeedAnalysisModel? value)
-        {
-            OnPropertyChanged(nameof(HasAnalysisResults));
-            OnPropertyChanged(nameof(AnalysisHeader));
         }
 
         #endregion

--- a/src/BalatroSeedOracle/ViewModels/DeckAndStakeSelectorViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/DeckAndStakeSelectorViewModel.cs
@@ -19,9 +19,15 @@ namespace BalatroSeedOracle.ViewModels
         private readonly SpriteService _spriteService;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(SelectedDeckName))]
+        [NotifyPropertyChangedFor(nameof(SelectedDeckDisplayName))]
+        [NotifyPropertyChangedFor(nameof(SelectedDeckDescription))]
         private int _deckIndex;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(SelectedStakeName))]
+        [NotifyPropertyChangedFor(nameof(SelectedStakeDisplayName))]
+        [NotifyPropertyChangedFor(nameof(SelectedStakeDescription))]
         private int _stakeIndex;
 
         [ObservableProperty]
@@ -140,22 +146,18 @@ namespace BalatroSeedOracle.ViewModels
 
         partial void OnDeckIndexChanged(int value)
         {
-            // keep enum in sync
+            // keep enum in sync; dependent display properties are raised via
+            // [NotifyPropertyChangedFor] on _deckIndex.
             SelectedDeck = GetDeckEnum(value);
-            OnPropertyChanged(nameof(SelectedDeckName));
-            OnPropertyChanged(nameof(SelectedDeckDisplayName));
-            OnPropertyChanged(nameof(SelectedDeckDescription));
             UpdateDeckImage();
             RaiseSelectionChanged();
         }
 
         partial void OnStakeIndexChanged(int value)
         {
-            // keep enum in sync
+            // keep enum in sync; dependent display properties are raised via
+            // [NotifyPropertyChangedFor] on _stakeIndex.
             SelectedStake = GetStakeEnum(value);
-            OnPropertyChanged(nameof(SelectedStakeName));
-            OnPropertyChanged(nameof(SelectedStakeDisplayName));
-            OnPropertyChanged(nameof(SelectedStakeDescription));
             UpdateStakeImage();
             RaiseSelectionChanged();
         }

--- a/src/BalatroSeedOracle/ViewModels/FilterSelectionModalViewModel.cs
+++ b/src/BalatroSeedOracle/ViewModels/FilterSelectionModalViewModel.cs
@@ -27,10 +27,29 @@ namespace BalatroSeedOracle.ViewModels
 
         // Selected filter details
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ShowDetailsPanel))]
+        [NotifyPropertyChangedFor(nameof(ShowPlaceholder))]
+        [NotifyPropertyChangedFor(nameof(FilterName))]
+        [NotifyPropertyChangedFor(nameof(FilterAuthor))]
+        [NotifyPropertyChangedFor(nameof(FilterDescription))]
+        [NotifyPropertyChangedFor(nameof(CreatedDate))]
+        [NotifyPropertyChangedFor(nameof(SelectedDeckName))]
+        [NotifyPropertyChangedFor(nameof(SelectedStakeName))]
+        [NotifyPropertyChangedFor(nameof(DeckCardImage))]
+        [NotifyPropertyChangedFor(nameof(SelectedDeckDescription))]
+        [NotifyPropertyChangedFor(nameof(MustHaveCount))]
+        [NotifyPropertyChangedFor(nameof(ShouldHaveCount))]
+        [NotifyPropertyChangedFor(nameof(MustNotCount))]
+        [NotifyPropertyChangedFor(nameof(ShowFilterTab))]
+        [NotifyPropertyChangedFor(nameof(ShowScoreTab))]
+        [NotifyPropertyChangedFor(nameof(ShowDeckTab))]
         private FilterBrowserItem? _selectedFilter;
 
         // Active tab index
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ShowFilterTab))]
+        [NotifyPropertyChangedFor(nameof(ShowScoreTab))]
+        [NotifyPropertyChangedFor(nameof(ShowDeckTab))]
         private int _activeTabIndex = 0;
 
         // Details panel visibility
@@ -152,22 +171,9 @@ namespace BalatroSeedOracle.ViewModels
 
         partial void OnSelectedFilterChanged(FilterBrowserItem? value)
         {
-            OnPropertyChanged(nameof(ShowDetailsPanel));
-            OnPropertyChanged(nameof(ShowPlaceholder));
-            OnPropertyChanged(nameof(FilterName));
-            OnPropertyChanged(nameof(FilterAuthor));
-            OnPropertyChanged(nameof(FilterDescription));
-            OnPropertyChanged(nameof(CreatedDate));
-            OnPropertyChanged(nameof(SelectedDeckName));
-            OnPropertyChanged(nameof(SelectedStakeName));
-            OnPropertyChanged(nameof(DeckCardImage));
-            OnPropertyChanged(nameof(SelectedDeckDescription));
-            OnPropertyChanged(nameof(MustHaveCount));
-            OnPropertyChanged(nameof(ShouldHaveCount));
-            OnPropertyChanged(nameof(MustNotCount));
-            OnPropertyChanged(nameof(ShowFilterTab));
-            OnPropertyChanged(nameof(ShowScoreTab));
-            OnPropertyChanged(nameof(ShowDeckTab));
+            // Dependent display properties are raised via [NotifyPropertyChangedFor]
+            // on _selectedFilter. This hook only maps the selection to the
+            // deck/stake indices the DeckAndStakeSelector component binds to.
 
             // Update deck/stake indices for DeckSpinner display
             if (value is not null)
@@ -219,12 +225,6 @@ namespace BalatroSeedOracle.ViewModels
             }
         }
 
-        partial void OnActiveTabIndexChanged(int value)
-        {
-            OnPropertyChanged(nameof(ShowFilterTab));
-            OnPropertyChanged(nameof(ShowScoreTab));
-            OnPropertyChanged(nameof(ShowDeckTab));
-        }
 
         [RelayCommand]
         private void Search()


### PR DESCRIPTION
## What

Replaces hand-written `OnPropertyChanged(nameof(...))` fan-out in three ViewModels with declarative `[NotifyPropertyChangedFor]` / `[NotifyCanExecuteChangedFor]` attributes on the backing `[ObservableProperty]` fields — the idiomatic CommunityToolkit.Mvvm pattern the repo's MVVM conventions call for. The change is **behavior-preserving**: the generated setters raise exactly the same dependent-property and command-`CanExecute` notifications that the removed partial hooks did.

## Changes

- **`AnalyzeModalViewModel`** — `ActiveTab` / `DeckIndex` / `StakeIndex` / `CurrentAnalysis` dependent display properties and the `SeedInput` / `IsAnalyzing` command-CanExecute notifications are now wired via attributes; the redundant partial hooks are removed (the one remaining hook still calls `UpdatePlaceholderVisibility`). Also fixes an obfuscated double-negative in `HasAnalysisResults` (`!string.IsNullOrEmpty(Error) == false`) to the equivalent, readable `string.IsNullOrEmpty(Error)`.
- **`DeckAndStakeSelectorViewModel`** — deck/stake display dependents moved onto the index fields. The same-index refresh path in the enum-change hooks is deliberately untouched (those manual raises fire when the index does *not* change, which `[NotifyPropertyChangedFor]` does not cover).
- **`FilterSelectionModalViewModel`** — 16 `SelectedFilter` dependents and the `ActiveTabIndex` tab-visibility dependents moved to attributes; the selection→deck/stake-index mapping logic stays in the hook. The manual notifications in `Configure()` are intentionally left as-is because those properties (`EnableSearch` etc.) are plain auto-properties, not `[ObservableProperty]`.

## Verification

Reviewed by hand — every name passed to `[NotifyPropertyChangedFor]` / `[NotifyCanExecuteChangedFor]` resolves to an existing computed property or generated command in its class. This environment has no .NET SDK or the Motely submodule checked out, so I could not run `dotnet build` here; the changes are source-generator-only refactors with no new APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtamFY9c39CxdwXPFQyKmM)_