### PR TITLE
Fix parcel-release workflow paths

### DIFF
--- a/.github/workflows/parcel-release.yml
+++ b/.github/workflows/parcel-release.yml
@@ -1,0 +1,78 @@
+name: Parcel Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # Keep manual trigger for testing
+
+jobs:
+  build-and-package:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Install Parcel
+      env:
+        PARCEL_LICENSE_KEY: ${{ secrets.PARCEL_LICENSE_KEY }}
+      run: dotnet tool install --global AvaloniaUI.Parcel.Windows
+
+    - name: Add dotnet tools to PATH
+      run: echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Restore dependencies
+      run: dotnet restore src/BalatroSeedOracle/BalatroSeedOracle.csproj
+
+    - name: Build
+      run: dotnet build src/BalatroSeedOracle/BalatroSeedOracle.csproj --configuration Release --no-restore
+
+    - name: Package with Parcel
+      env:
+        PARCEL_LICENSE_KEY: ${{ secrets.PARCEL_LICENSE_KEY }}
+      run: |
+        cd src/BalatroSeedOracle
+        dotnet parcel BalatroSeedOracle.parcel --runtimes win-x64 linux-x64 osx-x64 --packages nsis deb dmg
+
+    - name: Upload Windows Installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-installer
+        path: src/BalatroSeedOracle/bin/packages/*.exe
+        if-no-files-found: error
+
+    - name: Upload macOS Bundle
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-bundle
+        path: src/BalatroSeedOracle/bin/packages/*.dmg
+        if-no-files-found: warn
+
+    - name: Upload Linux Package
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-package
+        path: src/BalatroSeedOracle/bin/packages/*.deb
+        if-no-files-found: warn
+
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          src/BalatroSeedOracle/bin/packages/*.exe
+          src/BalatroSeedOracle/bin/packages/*.dmg
+          src/BalatroSeedOracle/bin/packages/*.deb
+        draft: false
+        # Mark as pre-release if tag contains -rc, -beta, -alpha, or -preview
+        prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') || contains(github.ref, '-preview') }}
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR #11 tried to fix this and got closed unmerged. The workflow pointed at src/BalatroSeedOracle.csproj and src/BalatroSeedOracle.parcel, but the actual project moved to src/BalatroSeedOracle/ one level deeper. Every release since has been packaged by hand.

Fix: point restore/build/parcel steps at src/BalatroSeedOracle/, and correct the artifact/upload paths to src/BalatroSeedOracle/bin/packages/ to match.